### PR TITLE
Defineable key size

### DIFF
--- a/src/ec/ecdsa_i15_sign_raw.c
+++ b/src/ec/ecdsa_i15_sign_raw.c
@@ -147,7 +147,7 @@ br_ecdsa_i15_sign_raw(const br_ec_impl *impl,
 	 */
 	br_i15_from_monty(k, n, n0i);
 	br_i15_from_monty(k, n, n0i);
-	memcpy(tt, cd->order, nlen);
+	memcpy_P(tt, cd->order, nlen);
 	tt[nlen - 1] -= 2;
 	br_i15_modpow(k, tt, nlen, n, n0i, t1, t2);
 

--- a/src/inner.h
+++ b/src/inner.h
@@ -56,7 +56,7 @@
  * no more than 23833 bits). RSA key sizes beyond 3072 bits don't make a
  * lot of sense anyway.
  */
-#define BR_MAX_RSA_SIZE   4096
+#define BR_MAX_RSA_SIZE   2048
 
 /*
  * Minimum size for a RSA modulus (in bits); this value is used only to
@@ -82,7 +82,7 @@
  * of 8 (so that decoding an integer with that many bytes does not
  * overflow).
  */
-#define BR_MAX_EC_SIZE   528
+#define BR_MAX_EC_SIZE   256
 
 /*
  * Some macros to recognize the current architecture. Right now, we are


### PR DESCRIPTION
Could you please add the #ifndef around BR_MAX_RSA_SIZE and BR_MAX_EC_SIZE.

I need to compile a reduced version of bearssl for Tasmota, limiting to 2048 RSA and 256 EC, to save stack size. Adding these allows me to change only the compile directive, not touching the code.