### PR TITLE
Make BR_MAX_RSA_SIZE and BR_MAX_EC_SIZE definable at compile time

### DIFF
--- a/src/inner.h
+++ b/src/inner.h
@@ -56,7 +56,9 @@
  * no more than 23833 bits). RSA key sizes beyond 3072 bits don't make a
  * lot of sense anyway.
  */
+#ifndef BR_MAX_RSA_SIZE
 #define BR_MAX_RSA_SIZE   4096
+#endif
 
 /*
  * Minimum size for a RSA modulus (in bits); this value is used only to
@@ -82,7 +84,9 @@
  * of 8 (so that decoding an integer with that many bytes does not
  * overflow).
  */
+#ifndef BR_MAX_EC_SIZE
 #define BR_MAX_EC_SIZE   528
+#endif
 
 /*
  * Some macros to recognize the current architecture. Right now, we are


### PR DESCRIPTION
Could you please add the #ifndef around BR_MAX_RSA_SIZE and BR_MAX_EC_SIZE.

I need to compile a reduced version of bearssl for Tasmota, limiting to 2048 RSA and 256 EC, to save stack size. Adding these allows me to change only the compile directive, not touching the code.