### PR TITLE
Set #define DBR_SLOW_MUL15 1 which saves at least 8.5k of code when using EC

### DIFF
--- a/conf/esp8266.mk
+++ b/conf/esp8266.mk
@@ -11,7 +11,7 @@ BUILD = esp8266
 TOOLCHAIN_PREFIX := xtensa-lx106-elf-
 CC := $(TOOLCHAIN_PREFIX)gcc
 CFLAGS = -W -Wall -g -O2 -Wpointer-arith -Wl,-EL -nostdlib -mlongcalls -mno-text-section-literals -ffunction-sections -fdata-sections -Werror
-CFLAGS += -D__ets__ -DICACHE_FLASH -DESP8266
+CFLAGS += -D__ets__ -DICACHE_FLASH -DESP8266 -DBR_SLOW_MUL15=1
 LD := $(TOOLCHAIN_PREFIX)ld
 AR := $(TOOLCHAIN_PREFIX)ar
 


### PR DESCRIPTION
Analysing the code size of libbearssl.a when using EC P256R1, I realized mul20() and square20() take a lot of space in flash.

Forcing BR_SLOW_MUL15 saves 8.5k for Tasmota with no observable performance impact.
