### PR TITLE
Rewritten inner loop of br_i15_montymul to not use pgm_read_word() v2

### DIFF
--- a/src/hash/sha2small.c
+++ b/src/hash/sha2small.c
@@ -215,7 +215,7 @@ sha2small_update(br_sha224_context *cc, const void *data, size_t len)
 		if (clen > len) {
 			clen = len;
 		}
-		memcpy(cc->buf + ptr, buf, clen);
+		memcpy_P(cc->buf + ptr, buf, clen);
 		ptr += clen;
 		buf += clen;
 		len -= clen;

--- a/src/rsa/rsa_i15_pub.c
+++ b/src/rsa/rsa_i15_pub.c
@@ -50,7 +50,7 @@ br_rsa_i15_public(unsigned char *x, size_t xlen,
 	 */
 	n = pk->n;
 	nlen = pk->nlen;
-	while (nlen > 0 && *n == 0) {
+	while (nlen > 0 && pgm_read_byte(n) == 0) {
 		n ++;
 		nlen --;
 	}

--- a/src/x509/x509_minimal.c
+++ b/src/x509/x509_minimal.c
@@ -375,14 +375,14 @@ eqbigint(const unsigned char *b1, size_t len1,
 		b1 ++;
 		len1 --;
 	}
-	while (len2 > 0 && *b2 == 0) {
+	while (len2 > 0 && pgm_read_byte(b2) == 0) {
 		b2 ++;
 		len2 --;
 	}
 	if (len1 != len2) {
 		return 0;
 	}
-	return memcmp(b1, b2, len1) == 0;
+	return memcmp_P(b1, b2, len1) == 0;
 }
 
 /*
@@ -434,7 +434,7 @@ static int check_single_direct_trust(br_x509_minimal_context *ctx,
 		return 0;
 	}
 	kt = ctx->pkey.key_type;
-	if ((ta->pkey.key_type & 0x0F) != kt) {
+	if ((pgm_read_byte(&ta->pkey.key_type) & 0x0F) != kt) {
 		return 0;
 	}
 	switch (kt) {
@@ -454,7 +454,7 @@ static int check_single_direct_trust(br_x509_minimal_context *ctx,
 	case BR_KEYTYPE_EC:
 		if (ctx->pkey.key.ec.curve != ta->pkey.key.ec.curve
 			|| ctx->pkey.key.ec.qlen != ta->pkey.key.ec.qlen
-			|| memcmp(ctx->pkey.key.ec.q,
+			|| memcmp_P(ctx->pkey.key.ec.q,
 				ta->pkey.key.ec.q,
 				ta->pkey.key.ec.qlen) != 0)
 		{
@@ -1737,7 +1737,7 @@ verify_signature(br_x509_minimal_context *ctx, const br_x509_pkey *pk)
 	int kt;
 
 	kt = ctx->cert_signer_key_type;
-	if ((pk->key_type & 0x0F) != kt) {
+	if ((pgm_read_byte(&pk->key_type) & 0x0F) != kt) {
 		return BR_ERR_X509_WRONG_KEY_TYPE;
 	}
 	switch (kt) {
@@ -1774,5 +1774,3 @@ verify_signature(br_x509_minimal_context *ctx, const br_x509_pkey *pk)
 		return BR_ERR_X509_UNSUPPORTED;
 	}
 }
-
-

--- a/src/x509/x509_minimal.t0
+++ b/src/x509/x509_minimal.t0
@@ -323,14 +323,14 @@ eqbigint(const unsigned char *b1, size_t len1,
 		b1 ++;
 		len1 --;
 	}
-	while (len2 > 0 && *b2 == 0) {
+	while (len2 > 0 && pgm_read_byte(b2) == 0) {
 		b2 ++;
 		len2 --;
 	}
 	if (len1 != len2) {
 		return 0;
 	}
-	return memcmp(b1, b2, len1) == 0;
+	return memcmp_P(b1, b2, len1) == 0;
 }
 
 /*
@@ -382,7 +382,7 @@ static int check_single_direct_trust(br_x509_minimal_context *ctx,
 		return 0;
 	}
 	kt = ctx->pkey.key_type;
-	if ((ta->pkey.key_type & 0x0F) != kt) {
+	if ((pgm_read_byte(&ta->pkey.key_type) & 0x0F) != kt) {
 		return 0;
 	}
 	switch (kt) {
@@ -402,7 +402,7 @@ static int check_single_direct_trust(br_x509_minimal_context *ctx,
 	case BR_KEYTYPE_EC:
 		if (ctx->pkey.key.ec.curve != ta->pkey.key.ec.curve
 			|| ctx->pkey.key.ec.qlen != ta->pkey.key.ec.qlen
-			|| memcmp(ctx->pkey.key.ec.q,
+			|| memcmp_P(ctx->pkey.key.ec.q,
 				ta->pkey.key.ec.q,
 				ta->pkey.key.ec.qlen) != 0)
 		{
@@ -456,7 +456,7 @@ verify_signature(br_x509_minimal_context *ctx, const br_x509_pkey *pk)
 	int kt;
 
 	kt = ctx->cert_signer_key_type;
-	if ((pk->key_type & 0x0F) != kt) {
+	if ((pgm_read_byte(&pk->key_type) & 0x0F) != kt) {
 		return BR_ERR_X509_WRONG_KEY_TYPE;
 	}
 	switch (kt) {


### PR DESCRIPTION
Cleaned version of #14

Using pre-parsed TA, PrivKey and Chain (generated from bearssl CLI) directly in PMEM requires additional changes.

It was tested with RSA Trusted Anchor, and EC P256R1 Private Key + Certificate.