### PR TITLE
Special yield() variant for thunk'ed functions

### DIFF
--- a/src/ec/ec_prime_i15.c
+++ b/src/ec/ec_prime_i15.c
@@ -465,7 +465,7 @@ run_code(jacobian *P1, const jacobian *P2,
 	memcpy(t[P1x], P1->c, 3 * I15_LEN * sizeof(uint16_t));
 	memcpy(t[P2x], P2->c, 3 * I15_LEN * sizeof(uint16_t));
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Run formulas.

--- a/src/ec/ec_prime_i31.c
+++ b/src/ec/ec_prime_i31.c
@@ -464,7 +464,7 @@ run_code(jacobian *P1, const jacobian *P2,
 	memcpy(t[P1x], P1->c, 3 * I31_LEN * sizeof(uint32_t));
 	memcpy(t[P2x], P2->c, 3 * I31_LEN * sizeof(uint32_t));
 
-        optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Run formulas.

--- a/src/inner.h
+++ b/src/inner.h
@@ -2595,13 +2595,13 @@ br_cpuid(uint32_t mask_eax, uint32_t mask_ebx,
   #endif
 
   #define _debugBearSSL (0)
-  extern void optimistic_yield(uint32_t);
+  extern void stack_thunk_yield();
   #ifdef __cplusplus
   }
   #endif
 
 #else
-  #define optimistic_yield(ignored)
+  #define stack_thunk_yield()
 #endif
 
 

--- a/src/inner.h
+++ b/src/inner.h
@@ -2595,7 +2595,7 @@ br_cpuid(uint32_t mask_eax, uint32_t mask_ebx,
   #endif
 
   #define _debugBearSSL (0)
-  extern void stack_thunk_yield();
+  extern void stack_thunk_yield(void);
   #ifdef __cplusplus
   }
   #endif

--- a/src/rsa/rsa_i15_priv.c
+++ b/src/rsa/rsa_i15_priv.c
@@ -141,7 +141,7 @@ br_rsa_i15_private(unsigned char *x, const br_rsa_private_key *sk)
 	mp = mq + 2 * fwlen;
 	memmove(mp, t1, fwlen * sizeof *t1);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Compute s2 = x^dq mod q.
@@ -152,7 +152,7 @@ br_rsa_i15_private(unsigned char *x, const br_rsa_private_key *sk)
 	r &= br_i15_modpow_opt(s2, sk->dq, sk->dqlen, mq, q0i,
 		mq + 3 * fwlen, TLEN - 3 * fwlen);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Compute s1 = x^dq mod q.
@@ -184,7 +184,7 @@ br_rsa_i15_private(unsigned char *x, const br_rsa_private_key *sk)
 	br_i15_decode_reduce(t1, sk->iq, sk->iqlen, mp);
 	br_i15_montymul(t2, s1, t1, mp, p0i);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * h is now in t2. We compute the final result:

--- a/src/rsa/rsa_i31_priv.c
+++ b/src/rsa/rsa_i31_priv.c
@@ -135,7 +135,7 @@ br_rsa_i31_private(unsigned char *x, const br_rsa_private_key *sk)
 	mp = mq + 2 * fwlen;
 	memmove(mp, t1, fwlen * sizeof *t1);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 	
 	/*
 	 * Compute s2 = x^dq mod q.
@@ -146,7 +146,7 @@ br_rsa_i31_private(unsigned char *x, const br_rsa_private_key *sk)
 	r &= br_i31_modpow_opt(s2, sk->dq, sk->dqlen, mq, q0i,
 		mq + 3 * fwlen, TLEN - 3 * fwlen);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Compute s1 = x^dp mod p.
@@ -178,7 +178,7 @@ br_rsa_i31_private(unsigned char *x, const br_rsa_private_key *sk)
 	br_i31_decode_reduce(t1, sk->iq, sk->iqlen, mp);
 	br_i31_montymul(t2, s1, t1, mp, p0i);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * h is now in t2. We compute the final result:


### PR DESCRIPTION
cont_suspend() wants stack pointer to be within cont.stack[] and panic()s otherwise https://github.com/esp8266/Arduino/issues/9170#issue-2425737426

stack_thunk_yield() func then gets added from the Core side, which should do 'SP store -> can_yield && yield() -> SP restore' with known stack thunk values https://github.com/esp8266/Arduino/compare/master...mcspr:esp8266-Arduino:bssl/9170-thunk
(maybe with less inline asm though)